### PR TITLE
Performance improvements & DMagic API fixes

### DIFF
--- a/X-Science/Config.cs
+++ b/X-Science/Config.cs
@@ -24,6 +24,7 @@ namespace ScienceChecklist {
 			private bool _filterDifficultScience;
 			private float _uiScale;
 			private bool _musicStartsMuted;
+			private bool _checkUnloadedVessels;
 			private bool _righClickMutesMusic;
 			private bool _selectedObjectWindow;
 
@@ -59,6 +60,7 @@ namespace ScienceChecklist {
 				}
 			}
 			public bool SelectedObjectWindow				{ get { return _selectedObjectWindow; }				set { if( _selectedObjectWindow != value ) { _selectedObjectWindow = value; OnSelectedObjectWindowChanged( ); } } }
+			public bool CheckUnloadedVessels				{ get { return _checkUnloadedVessels; }					set { if(_checkUnloadedVessels != value ) { _checkUnloadedVessels = value; OnCheckUnloadedVesselsChanged( ); } } }
 
 
 
@@ -76,6 +78,7 @@ namespace ScienceChecklist {
 			public event EventHandler MusicStartsMutedChanged;
  			public event EventHandler RighClickMutesMusicChanged;
 			public event EventHandler SelectedObjectWindowChanged;
+			public event EventHandler CheckUnloadedVesselsChanged;
 			
 
 
@@ -184,6 +187,14 @@ namespace ScienceChecklist {
 				}
 			}
 
+			private void OnCheckUnloadedVesselsChanged( )
+			{
+				if( CheckUnloadedVesselsChanged != null )
+				{
+					CheckUnloadedVesselsChanged( this, EventArgs.Empty );
+				}
+			}
+
 		public Config( )
 		{
 			_logger = new Logger( this );
@@ -267,6 +278,7 @@ namespace ScienceChecklist {
 			settings.AddValue( "FilterDifficultScience",		_filterDifficultScience );
 			settings.AddValue( "UiScale",						_uiScale );
 			settings.AddValue( "MusicStartsMuted",				_musicStartsMuted );
+			settings.AddValue( "CheckUnloadedVessels",			_checkUnloadedVessels );
 			settings.AddValue( "RighClickMutesMusic",			_righClickMutesMusic );
 			settings.AddValue( "SelectedObjectWindow",			_selectedObjectWindow );
 
@@ -306,6 +318,7 @@ namespace ScienceChecklist {
 			_filterDifficultScience =		true;
 			_uiScale =						1f;
 			_musicStartsMuted =				false;
+			_checkUnloadedVessels =			false;
 			_righClickMutesMusic =			true;
 			_selectedObjectWindow =			true;
 
@@ -375,6 +388,10 @@ namespace ScienceChecklist {
 					V = settings.GetValue( "SelectedObjectWindow" );
 					if( V != null )
 						_selectedObjectWindow = bool.Parse( V );
+
+					V = settings.GetValue( "CheckUnloadedVessels" );
+					if( V != null )
+						_checkUnloadedVessels = bool.Parse( V );
 
 
 

--- a/X-Science/DMagic.cs
+++ b/X-Science/DMagic.cs
@@ -35,7 +35,7 @@ namespace ScienceChecklist
 
 			_tDMAPI =							getType( "DMagic.DMAPI" );
 			_tDMModuleScienceAnimate =			getType( "DMagic.Part_Modules.DMModuleScienceAnimate" );
-			_tDMModuleScienceAnimateGeneric =	getType( "DMagic.Part_Modules.DMModuleScienceAnimateGeneric" );
+			_tDMModuleScienceAnimateGeneric =	getType( "DMModuleScienceAnimateGeneric.DMModuleScienceAnimateGeneric" );
 			_tDMBasicScienceModule =			getType( "DMagic.Part_Modules.DMBasicScienceModule" );
 
 
@@ -163,7 +163,7 @@ namespace ScienceChecklist
 
 			_MIdeployDMExperiment = tDMAPI.GetMethod("deployDMExperiment", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
 			p = _MIdeployDMExperiment.GetParameters();
-			if (!((p.Length == 2) && (p[0].ParameterType == typeof(IScienceDataContainer)) && (p[1].ParameterType == typeof(bool)) && _MIdeployDMExperiment.ReturnType == typeof(bool)))
+			if (!((p.Length == 2) && (p[0].ParameterType == typeof(ModuleScienceExperiment)) && (p[1].ParameterType == typeof(bool)) && _MIdeployDMExperiment.ReturnType == typeof(bool)))
 			{
 				_logger.Info( "DMAPI.deployDMExperiment method signature has changed. [x] Science may not work for DMagic experiments" );
 				_MIdeployDMExperiment = null;

--- a/X-Science/ExperimentFilter.cs
+++ b/X-Science/ExperimentFilter.cs
@@ -192,13 +192,13 @@ namespace ScienceChecklist {
 		private bool IsAmountLimitedByDMagic(ScienceInstance x, IList<ModuleScienceExperiment> DMModuleScienceAnimateGenerics)
 		{
 			if (DMModuleScienceAnimateGenerics == null || DMModuleScienceAnimateGenerics.Count == 0)
-				return true;
+				return false;
 			
 			var dmm = DMModuleScienceAnimateGenerics.FirstOrDefault(d => d.experimentID == x.ScienceExperiment.id);
-			if (dmm == null) return true;
+			if (dmm == null) return false;
 			
 			var f = (float)dmm.Fields.GetValue("totalScienceLevel");
-			if (f == 1f) return true;
+			if (f == 1f) return false;
 
 			var completedScience = x.ScienceSubject.science * HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier;
 			var totalScience = x.ScienceSubject.scienceCap * HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier * f;

--- a/X-Science/ExperimentFilter.cs
+++ b/X-Science/ExperimentFilter.cs
@@ -104,7 +104,7 @@ namespace ScienceChecklist {
 		/// <summary>
 		/// Recalculates the experiments to be displayed.
 		/// </summary>
-		public void UpdateFilter () {
+		public void UpdateFilter ( IList<ModuleScienceExperiment>  DMModuleScienceAnimateGenerics = null) {
 			var StartTime = DateTime.Now;
 //			_logger.Trace("UpdateFilter");
 			var query = _parent.Science.AllScienceInstances.AsEnumerable( );
@@ -162,7 +162,7 @@ namespace ScienceChecklist {
 
 			if( CompleteWithoutRecovery ) // Lab lander mode.  Complete is a green bar ( Recovered+OnBoard )
 			{
-				DisplayScienceInstances = query.Where( x => !HideCompleteExperiments || !x.IsCollected ).ToList( );
+				DisplayScienceInstances = query.Where( x => !HideCompleteExperiments || !x.IsCollected && !IsAmountLimitedByDMagic(x, DMModuleScienceAnimateGenerics) ).ToList( );
 
 				IList<ScienceInstance> RemainingExperiments = new List<ScienceInstance>( );
 				RemainingExperiments = query.Where( x => !x.IsCollected ).ToList( );
@@ -172,7 +172,7 @@ namespace ScienceChecklist {
 			}
 			else // Normal mode, must recover/transmit to KSC
 			{
-				DisplayScienceInstances = query.Where( x => !HideCompleteExperiments || !x.IsComplete ).ToList( );
+				DisplayScienceInstances = query.Where( x => !HideCompleteExperiments || !x.IsComplete && !IsAmountLimitedByDMagic(x, DMModuleScienceAnimateGenerics) ).ToList( );
 
 				IList<ScienceInstance> RemainingExperiments = new List<ScienceInstance>( );
 				RemainingExperiments = query.Where( x => !x.IsComplete ).ToList( );
@@ -185,6 +185,26 @@ namespace ScienceChecklist {
 
 			var Elapsed = DateTime.Now - StartTime;
 //			_logger.Trace( "UpdateFilter Done - " + Elapsed.ToString( ) + "ms" );
+		}
+
+
+
+		private bool IsAmountLimitedByDMagic(ScienceInstance x, IList<ModuleScienceExperiment> DMModuleScienceAnimateGenerics)
+		{
+			if (DMModuleScienceAnimateGenerics == null || DMModuleScienceAnimateGenerics.Count == 0)
+				return true;
+			
+			var dmm = DMModuleScienceAnimateGenerics.FirstOrDefault(d => d.experimentID == x.ScienceExperiment.id);
+			if (dmm == null) return true;
+			
+			var f = (float)dmm.Fields.GetValue("totalScienceLevel");
+			if (f == 1f) return true;
+
+			var completedScience = x.ScienceSubject.science * HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier;
+			var totalScience = x.ScienceSubject.scienceCap * HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier * f;
+			var isComplete = completedScience > totalScience || totalScience - completedScience < 0.1;
+
+			return isComplete;
 		}
 
 

--- a/X-Science/GameData/[x] Science!/PluginData/[x] Science!/settings.cfg
+++ b/X-Science/GameData/[x] Science!/PluginData/[x] Science!/settings.cfg
@@ -15,5 +15,6 @@ ScienceChecklist
 		MusicStartsMuted = False
 		RighClickMutesMusic = True
 		SelectedObjectWindow = True
+		CheckUnloadedVessels = False
 	}
 }

--- a/X-Science/GameData/[x] Science!/[x] Science!.version
+++ b/X-Science/GameData/[x] Science!/[x] Science!.version
@@ -9,10 +9,16 @@
         "MINOR":21,
         "PATCH":0
     },
-    "KSP_VERSION":
+    "KSP_VERSION_MIN":
     {
-        "MAJOR":1,
-        "MINOR":7,
-        "PATCH":0
+        "MAJOR": 1,
+        "MINOR": 5,
+        "PATCH": 0
+    },
+    "KSP_VERSION_MAX":
+    {
+        "MAJOR": 1,
+        "MINOR": 7,
+        "PATCH": 9
     }
 }

--- a/X-Science/ScienceContext.cs
+++ b/X-Science/ScienceContext.cs
@@ -152,35 +152,36 @@ namespace ScienceChecklist
 				}
 
 
-			// TODO: the code below causes performance issues and was commented out because of that
+			// NOTE: The code below causes performance issues and should be disabled by default
 			// Look for science in unloaded vessels.
 			// Don't do debris or already loaded vessels(from routine above)
 			// I was having execptions because something was NULL.
 			// Only happend on a brand-new game, not a load.
 			// This seemed to fix it
-				//if( HighLogic.CurrentGame != null && HighLogic.CurrentGame.flightState != null )
-				//{
-				//	// Dump all the vessels to a save.
-				//	var node = new ConfigNode( );
-				//	HighLogic.CurrentGame.flightState.Save( node );
-				//	if( node == null )
-				//		_logger.Trace( "flightState save is null" );
-				//	else
-				//	{
-				//		// Grab the unloaded vessels
-				//		ConfigNode[] vessels = node.GetNodes( "VESSEL" );
-				//		onboardScience.AddRange
-				//		(
-				//			vessels.Where( x => _parent.Config.CheckDebris || x.GetValue( "type" ) != "Debris" )
-				//				.Where( x => !vesselIds.Contains( x.GetValue( "pid" ) ) ) // Not the active ones, we have them already
-				//					.SelectMany( x => x.GetNodes( "PART" )
-				//						.SelectMany( y => y.GetNodes( "MODULE" )
-				//							.SelectMany( z => z.GetNodes( "ScienceData" ) ).Select( z => new ScienceData( z ) )
-				//						)
-				//					)
-				//		);
-				//	}
-				//}
+				if( HighLogic.CurrentGame != null && HighLogic.CurrentGame.flightState != null &&
+					_parent.Config.CheckUnloadedVessels)
+				{
+					// Dump all the vessels to a save.
+					var node = new ConfigNode( );
+					HighLogic.CurrentGame.flightState.Save( node );
+					if( node == null )
+						_logger.Trace( "flightState save is null" );
+					else
+					{
+						// Grab the unloaded vessels
+						ConfigNode[] vessels = node.GetNodes( "VESSEL" );
+						onboardScience.AddRange
+						(
+							vessels.Where( x => _parent.Config.CheckDebris || x.GetValue( "type" ) != "Debris" )
+								.Where( x => !vesselIds.Contains( x.GetValue( "pid" ) ) ) // Not the active ones, we have them already
+									.SelectMany( x => x.GetNodes( "PART" )
+										.SelectMany( y => y.GetNodes( "MODULE" )
+											.SelectMany( z => z.GetNodes( "ScienceData" ) ).Select( z => new ScienceData( z ) )
+										)
+									)
+						);
+					}
+				}
 
 
 

--- a/X-Science/ScienceInstance.cs
+++ b/X-Science/ScienceInstance.cs
@@ -100,11 +100,15 @@ namespace ScienceChecklist {
 		/// <param name="onboardScience">The total onboard ScienceData.</param>
 		public void Update( ScienceContext Sci )
 		{
-			if( Sci.ScienceSubjects.ContainsKey( Id ) )
-				ScienceSubject = Sci.ScienceSubjects[ Id ];
-			else ScienceSubject = new ScienceSubject(ScienceExperiment, Situation.ExperimentSituation, Situation.Body.CelestialBody, Situation.SubBiome ?? Situation.Biome ?? string.Empty);
-
-
+			ScienceSubject tmp;
+			if( Sci.ScienceSubjects.TryGetValue( Id, out tmp ) )
+				ScienceSubject = tmp;
+			else
+			{
+					ScienceSubject = new ScienceSubject(ScienceExperiment, Situation.ExperimentSituation, Situation.Body.CelestialBody, Situation.SubBiome ?? Situation.Biome ?? string.Empty);
+					Sci.ScienceSubjects.Add( Id, ScienceSubject );
+			}
+			
 			IsUnlocked = Sci.UnlockedInstruments.IsUnlocked( ScienceExperiment.id ) && ( Situation.Body.Reached != null );
 
 			CompletedScience = ScienceSubject.science * HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier;

--- a/X-Science/SettingsWindow.cs
+++ b/X-Science/SettingsWindow.cs
@@ -74,6 +74,13 @@ namespace ScienceChecklist
 				save = true;
 			}
 
+			toggle = GUILayout.Toggle(_parent.Config.CheckUnloadedVessels, new GUIContent("Check unloaded vessels", "Unloaded vessels will be checked for recoverable science."), toggleStyle);
+			if( toggle != _parent.Config.CheckUnloadedVessels )
+			{
+				_parent.Config.CheckUnloadedVessels = toggle;
+				save = true;
+			}
+
 			toggle = GUILayout.Toggle( _parent.Config.CheckDebris, new GUIContent( "Check debris", "Vessels marked as debris will be checked for recoverable science." ), toggleStyle );
 			if( toggle != _parent.Config.CheckDebris )
 			{

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -505,20 +505,23 @@ namespace ScienceChecklist
 				DMModuleScienceAnimateGeneric NewDMagicInstance = _parent.DMagic.GetDMModuleScienceAnimateGeneric( );
 				if( NewDMagicInstance != null )
 				{
-					IEnumerable<ModuleScienceExperiment> lm = _DMModuleScienceAnimateGenerics.Where(x => (
-						x.experimentID == s.ScienceExperiment.id &&
-						!x.Inoperable &&
-						((int)x.Fields.GetValue("experimentsLimit") > 1 ? NewDMagicInstance.canConduct(x) : NewDMagicInstance.canConduct(x) && (x.rerunnable || runSingleUse))
-						));
-					if (lm.Count() != 0)
-						m = lm.First();
-
-					if (m != null)
+					IEnumerable<ModuleScienceExperiment> lm = _DMModuleScienceAnimateGenerics.Where(x => x.experimentID == s.ScienceExperiment.id);
+					if (lm.Any())
 					{
-						_logger.Debug("Running DMModuleScienceAnimateGenerics Experiment " + m.experimentID + " on part " + m.part.partInfo.name);
-						NewDMagicInstance.gatherScienceData( m, !_parent.Config.ShowResultsWindow );
+						m = lm.FirstOrDefault(x =>
+							(int)x.Fields.GetValue("experimentsLimit") > 1 ? NewDMagicInstance.canConduct(x) : NewDMagicInstance.canConduct(x) && 
+							(x.rerunnable || runSingleUse)
+							);
+
+						if (m != null)
+						{
+							_logger.Debug("Running DMModuleScienceAnimateGenerics Experiment " + m.experimentID + " on part " + m.part.partInfo.name);
+							NewDMagicInstance.gatherScienceData( m, !_parent.Config.ShowResultsWindow );
+						}
+
 						return;
 					}
+
 				}
 			}
 
@@ -530,19 +533,22 @@ namespace ScienceChecklist
 				DMAPI DMAPIInstance = _parent.DMagic.GetDMAPI( );
 				if( DMAPIInstance != null )
 				{
-					IEnumerable<ModuleScienceExperiment> lm = _DMModuleScienceAnimates.Where(x =>
+					IEnumerable<ModuleScienceExperiment> lm = _DMModuleScienceAnimates.Where(x => x.experimentID == s.ScienceExperiment.id);
+					if (lm.Any())
 					{
-						return x.experimentID == s.ScienceExperiment.id &&
-						!x.Inoperable &&
-						((int)x.Fields.GetValue("experimentLimit") > 1 ? DMAPIInstance.experimentCanConduct(x) : DMAPIInstance.experimentCanConduct(x) && (x.rerunnable || runSingleUse));
-					});
-					if (lm.Count() != 0)
-						m = lm.First();
+						m = lm.FirstOrDefault(x =>
+						{
+							return !x.Inoperable &&
+							((int)x.Fields.GetValue("experimentLimit") > 1 ? DMAPIInstance.experimentCanConduct(x) : DMAPIInstance.experimentCanConduct(x) && 
+							(x.rerunnable || runSingleUse));
+						});
 
-					if (m != null)
-					{
-						_logger.Trace("Running DMModuleScienceAnimates Experiment " + m.experimentID + " on part " + m.part.partInfo.name);
-						DMAPIInstance.deployDMExperiment( m, !_parent.Config.ShowResultsWindow );
+						if (m != null)
+						{
+							_logger.Trace("Running DMModuleScienceAnimates Experiment " + m.experimentID + " on part " + m.part.partInfo.name);
+							DMAPIInstance.deployDMExperiment( m, !_parent.Config.ShowResultsWindow );
+						}
+
 						return;
 					}
 				}

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -389,7 +389,7 @@ namespace ScienceChecklist
 
 
 
-			_filter.UpdateFilter( );
+			_filter.UpdateFilter( _DMModuleScienceAnimateGenerics );
 		}
 
 

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -508,7 +508,7 @@ namespace ScienceChecklist
 					IEnumerable<ModuleScienceExperiment> lm = _DMModuleScienceAnimateGenerics.Where(x => (
 						x.experimentID == s.ScienceExperiment.id &&
 						!x.Inoperable &&
-						((int)x.Fields.GetValue("experimentLimit") > 1 ? NewDMagicInstance.canConduct(x) : NewDMagicInstance.canConduct(x) && (x.rerunnable || runSingleUse))
+						((int)x.Fields.GetValue("experimentsLimit") > 1 ? NewDMagicInstance.canConduct(x) : NewDMagicInstance.canConduct(x) && (x.rerunnable || runSingleUse))
 						));
 					if (lm.Count() != 0)
 						m = lm.First();

--- a/X-Science/xScienceEventHandler.cs
+++ b/X-Science/xScienceEventHandler.cs
@@ -66,7 +66,6 @@ namespace ScienceChecklist
 			GameEvents.onGameStateSave.Add( new EventData<ConfigNode>.OnEvent( this.GameStateSave ) );
 			GameEvents.OnPartPurchased.Add( new EventData<AvailablePart>.OnEvent( this.PartPurchased ) );
 			GameEvents.OnTechnologyResearched.Add( new EventData<GameEvents.HostTargetAction<RDTech, RDTech.OperationResult>>.OnEvent( this.TechnologyResearched ) );
-			GameEvents.OnScienceChanged.Add( new EventData<float, TransactionReasons>.OnEvent( this.ScienceChanged ) );
 			GameEvents.OnScienceRecieved.Add( new EventData<float, ScienceSubject, ProtoVessel, bool>.OnEvent( this.ScienceRecieved ) );
 			GameEvents.onVesselRename.Add( new EventData<GameEvents.HostedFromToAction<Vessel, string>>.OnEvent( this.VesselRename ) );
 			GameEvents.OnKSCFacilityUpgraded.Add( new EventData<Upgradeables.UpgradeableFacility, int>.OnEvent( this.FacilityUpgrade ) );
@@ -248,12 +247,6 @@ namespace ScienceChecklist
 			private void GameStateSave( ConfigNode C )
 			{
 //				_logger.Trace( "Callback: GameStateSave" );
-				ScheduleExperimentUpdate( );
-			}
-
-			private void ScienceChanged( float V, TransactionReasons R )
-			{
-//				_logger.Trace( "Callback: ScienceChanged" );
 				ScheduleExperimentUpdate( );
 			}
 


### PR DESCRIPTION
Fixed major performance issues with RSS/RO/RP-1 by not calculating the entire science data again after each change on the vessel. Another huge performance improvement came from not checking stored experiments on other unloaded vessels. I made a config toggle for that functionality but it's now disabled by default.
Integration with DMModuleScienceAnimateGeneric also received a couple of fixes.

It would be nice if you'd mark your releases compatible with KSP versions starting from 1.5. CKAN supports that just fine. All you'd need to do is compile this mod with references to KSP 1.5 DLLs and it would work with up to KSP 1.7 and possibly also with future updates. I could do another PR for the version file if you'd like.