### PR TITLE
Fix science gain in 1.7.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ bin
 obj
 /X-Science/*.user
 /X-Science/*.suo
-.svn
+/X-Science/.vs/

--- a/X-Science/ScienceInstance.cs
+++ b/X-Science/ScienceInstance.cs
@@ -1,4 +1,7 @@
-﻿
+﻿using System.Collections.Generic;
+
+
+
 namespace ScienceChecklist {
 	/// <summary>
 	/// An object that represents a ScienceExperiement in a given Situation.
@@ -115,25 +118,30 @@ namespace ScienceChecklist {
 			TotalScience = ScienceSubject.scienceCap * HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier;
 			IsComplete = CompletedScience > TotalScience || TotalScience - CompletedScience < 0.1;
 
-			var multiplier = ScienceExperiment.baseValue / ScienceExperiment.scienceCap;
-
-
-
 			OnboardScience = 0;
-			if( Sci.OnboardScienceList.ContainsKey( ScienceSubject.id ) )
-			{
-				var data = Sci.OnboardScienceList[ ScienceSubject.id ];
-//				var _logger = new Logger( "Experiment" );
-//				_logger.Trace( ScienceSubject.id + " found " + data.Count( ) + " items" );
-
+			List<ScienceData> data;
+			if( Sci.OnboardScienceList.TryGetValue( ScienceSubject.id, out data ) )
 				for( int x = 0; x < data.Count; x++ )
-				{
-					var next = (TotalScience - (CompletedScience + OnboardScience)) * multiplier;
-					OnboardScience += next;
-				}
-			}
+					OnboardScience += NextScienceGain(ScienceExperiment, CompletedScience + OnboardScience, TotalScience);
+
 			var AllCollectedScience = CompletedScience + OnboardScience;
 			IsCollected = AllCollectedScience > TotalScience || TotalScience - AllCollectedScience < 0.1;
+		}
+		#endregion
+
+		#region METHODS (private)
+		/// <summary>
+		/// Calculates science yield of next measurement.
+		/// </summary>
+		/// <param name="Experiment">The science experiment.</param>
+		/// <param name="CollectedScience">The science collected so far.</param>
+		/// <param name="TotalScience">The science cap.</param>
+		static float NextScienceGain(ScienceExperiment Experiment, float CollectedScience, float TotalScience)
+		{
+			var RemainingScience = TotalScience - CollectedScience;
+			var ScientificValue = Experiment.applyScienceScale ? 1 - (CollectedScience / TotalScience) : 1;
+			var Multiplier = Experiment.baseValue / Experiment.scienceCap;
+			return RemainingScience * ScientificValue * Multiplier;
 		}
 		#endregion
 	}


### PR DESCRIPTION
I fixed the science gain formula that takes into account scienceValue. It becomes default since 1.7.1 as discussed in forums.
I also added a small optimizations in science table lookup but it's inconsequential to the fix itself.