### PR TITLE
Fix version file URL property

### DIFF
--- a/X-Science/GameData/[x] Science!/[x] Science!.version
+++ b/X-Science/GameData/[x] Science!/[x] Science!.version
@@ -1,6 +1,6 @@
 {
     "NAME":"[x] Science!",
-    "URL":"http://ksp.floppy.men/[x] Science!/[x] Science!.version",
+    "URL":"https://ksp.floppy.men/%5Bx%5D%20Science%21/%5Bx%5D%20Science%21.version",
     "DOWNLOAD":"http://ksp.floppy.men/[x] Science!/x-science-v5.26.zip",
     "CHANGE_LOG_URL":"http://ksp.floppy.men/[x] Science!/CHANGES.md",
     "VERSION":


### PR DESCRIPTION
The current version file's URL property uses bracket `[]` characters, which aren't allowed inURLs.

https://tools.ietf.org/html/rfc1738

> Thus, only alphanumerics, the special characters "$-_.+!*'(),", and reserved characters used for their reserved purposes may be used unencoded within a URL.

Now it's fixed.